### PR TITLE
Specify version of build-dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Build-Depends:
  python3-cssselect,
  python3-dateutil,
  python3-dev,
- python3-feedparser,
+ python3-feedparser (>= 6.0.8-1~),
  python3-html2text,
  python3-html5-parser (>=0.4.10-1~),
  python3-html5lib,


### PR DESCRIPTION
`python3-html5-parser` added the keyword `fragment_context` for the `parse` function only in version 0.4.10.

I stumbled over this when trying to backport calibre.

With the `python3-html5-parser` version taken from stable, a test fails with

```
======================================================================
ERROR: test_html_transform_actions (calibre.ebooks.html_transform_rules.test.<locals>.TestTransforms)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/calibre-5.40.0+dfsg/src/calibre/ebooks/html_transform_rules.py", line 561, in test_html_transform_actions
    parse('a', fragment_context='div')
TypeError: parse() got an unexpected keyword argument 'fragment_context'
```