### PR TITLE
Create backport to fix CVE-2023-46303

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+calibre (5.44.0+dfsg-1~bpo11+2) bullseye-backports; urgency=medium
+
+  * Add patch to fix CVE-2023-46303.
+
+ -- Harlan Lieberman-Berg <hlieberman@debian.org>  Mon, 08 Jan 2024 19:28:28 -0500
+
 calibre (5.44.0+dfsg-1~bpo11+1) bullseye-backports; urgency=medium
 
   * Rebuild for bullseye-backports.

--- a/debian/patches/0017-fix-cve-2023-46303.patch
+++ b/debian/patches/0017-fix-cve-2023-46303.patch
@@ -1,0 +1,53 @@
+Origin: https://github.com/kovidgoyal/calibre/commit/bbbddd2bf4ef4ddb467b0aeb0abe8765ed7f8a6b.patch
+From: Kovid Goyal <kovid@kovidgoyal.net>
+Date: Sun, 28 May 2023 14:03:15 +0530
+Forwarded: not-needed
+Reviewed-By: Harlan Lieberman-Berg <hlieberman@debian.org>
+Subject: [PATCH] HTML Input: Dont add resources that exist outside the folder
+ hierarchy rooted at the parent folder of the input HTML file by default
+
+---
+ .../ebooks/conversion/plugins/html_input.py      | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+Index: calibre/src/calibre/ebooks/conversion/plugins/html_input.py
+===================================================================
+--- calibre.orig/src/calibre/ebooks/conversion/plugins/html_input.py
++++ calibre/src/calibre/ebooks/conversion/plugins/html_input.py
+@@ -64,6 +64,16 @@ class HTMLInput(InputFormatPlugin):
+                 )
+         ),
+ 
++        OptionRecommendation(name='allow_local_files_outside_root',
++            recommended_value=False, level=OptionRecommendation.LOW,
++            help=_('Normally, resources linked to by the HTML file or its children will only be allowed'
++                   ' if they are in a sub-folder of the original HTML file. This option allows including'
++                   ' local files from any location on your computer. This can be a security risk if you'
++                   ' are converting untrusted HTML and expecting to distribute the result of the conversion.'
++                )
++        ),
++
++
+     }
+ 
+     def convert(self, stream, opts, file_ext, log,
+@@ -76,6 +86,7 @@ class HTMLInput(InputFormatPlugin):
+         if hasattr(stream, 'name'):
+             basedir = os.path.dirname(stream.name)
+             fname = os.path.basename(stream.name)
++        self.root_dir_of_input = os.path.abspath(basedir) + os.sep
+ 
+         if file_ext != 'opf':
+             if opts.dont_package:
+@@ -250,6 +261,11 @@ class HTMLInput(InputFormatPlugin):
+         frag = l.fragment
+         if not link:
+             return None, None
++        link = os.path.abspath(os.path.realpath(link))
++        if not link.startswith(self.root_dir_of_input):
++            if not self.opts.allow_local_files_outside_root:
++                self.log.warn('Not adding {} as it is outside the document root: {}'.format(link, self.root_dir_of_input))
++                return None, None
+         return link, frag
+ 
+     def resource_adder(self, link_, base=None):

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,4 @@
 0014-Sort-object-lists-for-reproducible-build.patch
 0015-Extend-thread-wait-time-to-pass-test.patch
 0016-Sort-file-names-for-reproducible-build.patch
+0017-fix-cve-2023-46303.patch


### PR DESCRIPTION
A trivial inclusion of the patch from upstream is all that's required, along with bumping d/changelog for the release candidate.

I'm happy to sponsor your upload into backports if you don't have upload rights there, or if you'd prefer, I can just upload it myself.